### PR TITLE
Modernizing a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .nrepl-*
 target
-.boot
+.clj-kondo/
+.cp-cache/

--- a/build.boot
+++ b/build.boot
@@ -1,8 +1,8 @@
 (set-env!
-  :dependencies   '[[org.clojure/clojure "1.6.0" :scope "provided"]
-                    [org.jruby/jruby-complete "1.7.16.1"]
-                    [adzerk/bootlaces "0.1.5" :scope "test"]
-                    [adzerk/boot-test "1.0.3" :scope "test"]])
+ :dependencies '[[org.clojure/clojure "1.10.1" :scope "provided"]
+                 [org.jruby/jruby-complete "9.2.14.0" :scope "provided"]
+                 [adzerk/bootlaces "0.2.0" :scope "test"]
+                 [adzerk/boot-test "1.2.0" :scope "test"]])
 
 (require
   '[adzerk.bootlaces :refer :all]

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:deps {}
+ :aliases
+ {:dev {:extra-deps {org.clojure/clojure {:mvn/version"1.10.1"}
+                     org.jruby/jruby-complete {:mvn/version "9.2.14.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
 {:deps {}
+ :paths ["src" "resources"]
  :aliases
  {:dev {:extra-deps {org.clojure/clojure {:mvn/version"1.10.1"}
                      org.jruby/jruby-complete {:mvn/version "9.2.14.0"}}}}}

--- a/src/clj/rb.clj
+++ b/src/clj/rb.clj
@@ -56,10 +56,6 @@
   (clj->rb [_ _]
     nil)
 
-  Object
-  (clj->rb [v _]
-    v)
-
   clojure.lang.Keyword
   (clj->rb [v rt]
     (RubySymbol/newSymbol (ruby-runtime rt) (name v)))
@@ -74,13 +70,13 @@
     (reduce
       (fn [h [k v]] (doto h (.put (clj->rb k rt) (clj->rb v rt))))
       (RubyHash. (ruby-runtime rt))
-      v)))
+      v))
+
+  Object
+  (clj->rb [v _]
+    v))
 
 (extend-protocol Rb->Clj
-  Object
-  (rb->clj [v]
-    v)
-
   nil
   (rb->clj [_]
     nil)
@@ -97,7 +93,11 @@
 
   RubySymbol
   (rb->clj [v]
-    (keyword (str v))))
+    (keyword (str v)))
+
+  Object
+  (rb->clj [v]
+    v))
 
 (defn require
   "Requires each of `libs` in `rt`."

--- a/src/clj/rb.clj
+++ b/src/clj/rb.clj
@@ -182,7 +182,8 @@
      (doseq [[k v] env]
        (setenv rt k v))
      (require rt "rubygems")
-     (load rt (-> "clj-ruby-helpers/clj_rb_util.rb" io/resource))
+     (when-not (-> rt ruby-runtime (.isClassDefined "CljRbUtil"))
+       (eval rt (-> "clj-ruby-helpers/clj_rb_util.rb" io/resource slurp)))
      rt)))
 
 (defn install-gem

--- a/src/clj/rb.clj
+++ b/src/clj/rb.clj
@@ -46,7 +46,7 @@
       method-name (object-array (map #(clj->rb % rt) args)))))
 
 (defn- rb-helper [rt]
-  (eval rt "require 'clj_rb_util';CljRbUtil"))
+  (eval rt "CljRbUtil"))
 
 (defn- ruby-runtime [rt]
   (-> rt .getProvider .getRuntime))
@@ -141,13 +141,13 @@
      (let [rt (ScriptingContainer. (if preserve-locals?
                                      LocalVariableBehavior/PERSISTENT
                                      LocalVariableBehavior/TRANSIENT))]
-       (.setLoadPaths rt (conj load-paths
-                           (.toExternalForm (io/resource "clj-ruby-helpers"))))
+       (.setLoadPaths rt load-paths)
        (when-let [paths (seq gem-paths)]
          (setenv rt "GEM_PATH" (str/join ":" (map pr-str paths))))
        (doseq [[k v] env]
          (setenv rt k v))
-       (require "rubygems")
+       (eval-file rt (-> "clj-ruby-helpers/clj_rb_util.rb" io/resource io/reader))
+       (require rt "rubygems")
        rt)))
 
 

--- a/test/clj/rb_test.clj
+++ b/test/clj/rb_test.clj
@@ -1,5 +1,5 @@
 (ns clj.rb-test
-  (:refer-clojure :exclude [eval require])
+  (:refer-clojure :exclude [eval require load])
   (:require [clojure.test :refer :all]
             [clj.rb :refer :all]))
 


### PR DESCRIPTION
Hey there! I've been using clj.rb for a while now to embed a Ruby-based asset pipeline in a ClojureScript build. For example, boot-middleman uses it.

There are a few things here that I think modernize it.

1. With the latest versions of JRuby (not sure since which version), the default `LocalContextScope` has changed. By exposing the option, we can still get the original behavior.
2. I've added a protocol for "load"-ing a Ruby file/input stream. This works so that ruby scripts on the classpath (say, in a jar) can be loaded.
3. Added a `with-runtime` macro to wrap the common pattern of spin up, do work, terminate.

Thanks for this library!